### PR TITLE
This commit fixes #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 coverage/
 lib/
 node_modules/
+
+## IntellIJ files
+.idea
+*.iml

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -155,7 +155,7 @@ export function fetchEventSource(input: RequestInfo, {
 
 function defaultOnOpen(response: Response) {
     const contentType = response.headers.get('content-type');
-    if (contentType !== EventStreamContentType) {
+    if (!contentType.startsWith(EventStreamContentType)) {
         throw new Error(`Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`);
     }
 }


### PR DESCRIPTION
Makes the content type header check more forgiving, for instances where the charset encoding is included.