### PR TITLE
Add esnext build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
   },
   "author": "Microsoft",
   "license": "MIT",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/csj/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/csj/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "clean": "rimraf ./lib ./coverage",
     "prebuild": "npm run clean",
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "test": "nyc jasmine --config=jasmine.json",
     "prepublishOnly": "npm run build && npm run test"
   },

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./lib/esm",
+  },
+  "exclude": [
+      "src/**/*.spec.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "commonjs",
         "forceConsistentCasingInFileNames": true,
         "rootDir": "src",
-        "outDir": "lib",
+        "outDir": "lib/cjs",
         "declaration": true,
         "sourceMap": true,
         "removeComments": true,


### PR DESCRIPTION
Hey, thx for this lib!

We have to use esm import, I have added esm build and move default cjs build into cjs folder.

Is it acceptable?