### PR TITLE
Abort fetch before retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fetch-event-source",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A better API for making Event Source requests, with all the features of fetch()",
   "homepage": "https://github.com/Azure/fetch-event-source#readme",
   "repository": "github:Azure/fetch-event-source",

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -100,6 +100,9 @@ export function fetchEventSource(input: RequestInfo, {
         const fetch = inputFetch ?? window.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
+            if (curRequestController) {
+                curRequestController.abort();
+            }
             curRequestController = new AbortController();
             try {
                 const response = await fetch(input, {


### PR DESCRIPTION
The retry mechanism did not abort the original fetch which can lead to many open connections.