### PR TITLE
Makes FetchEventSource compatible with webworker

### DIFF
--- a/helpers/abortcontroller.js
+++ b/helpers/abortcontroller.js
@@ -1,0 +1,21 @@
+'use strict';
+
+class AbortController {
+    constructor() {
+        Object.defineProperty(this, 'signal', { value: {aborted: false}, writable: true, configurable: true });
+    }
+}
+    
+Object.defineProperty(global, 'AbortController', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: AbortController,
+});
+    
+Object.defineProperty(global, 'self', {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: global,
+});

--- a/jasmine.json
+++ b/jasmine.json
@@ -2,5 +2,8 @@
     "spec_dir": "lib",
     "spec_files": [
         "**/*.spec.js"
+    ],
+    "helpers": [
+      "../helpers/**/*.js"
     ]
 }

--- a/src/fetch.spec.ts
+++ b/src/fetch.spec.ts
@@ -1,0 +1,29 @@
+import * as fetch from "./fetch";
+
+describe("fetch", () => {
+  describe("fetchEventSource", () => {
+    it("cannot create event source since there is no document", () => {
+      fetch.fetchEventSource("http://localhost:3000", {}).catch((error) => {
+        expect(error).toEqual(new ReferenceError("document is not defined"));
+      });
+    });
+
+    it("cannot create event source since there is no window", () => {
+      fetch
+        .fetchEventSource("http://localhost:3000", { openWhenHidden: true })
+        .catch((error) => {
+          expect(error).toEqual(new ReferenceError("window is not defined"));
+        });
+    });
+
+    it("can create event source", () => {
+      const fetchStub = jasmine.createSpy();
+
+      const promise = fetch.fetchEventSource("http://localhost:3000", {
+        openWhenHidden: true,
+        fetch: fetchStub,
+      });
+      expect(promise).toBeDefined();
+    });
+  });
+});

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -89,7 +89,7 @@ export function fetchEventSource(input: RequestInfo, {
             if (!openWhenHidden) {
                 document.removeEventListener('visibilitychange', onVisibilityChange);
             }
-            window.clearTimeout(retryTimer);
+            self.clearTimeout(retryTimer);
             curRequestController.abort();
         }
 
@@ -133,8 +133,8 @@ export function fetchEventSource(input: RequestInfo, {
                     try {
                         // check if we need to retry:
                         const interval: any = onerror?.(err) ?? retryInterval;
-                        window.clearTimeout(retryTimer);
-                        retryTimer = window.setTimeout(create, interval);
+                        self.clearTimeout(retryTimer);
+                        retryTimer = self.setTimeout(create, interval);
                     } catch (innerErr) {
                         // we should not retry anymore:
                         dispose();

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -86,7 +86,9 @@ export function fetchEventSource(input: RequestInfo, {
         let retryInterval = DefaultRetryInterval;
         let retryTimer = 0;
         function dispose() {
-            document.removeEventListener('visibilitychange', onVisibilityChange);
+            if (!openWhenHidden) {
+                document.removeEventListener('visibilitychange', onVisibilityChange);
+            }
             window.clearTimeout(retryTimer);
             curRequestController.abort();
         }


### PR DESCRIPTION
Hello,

these changes (somehow similar to https://github.com/Azure/fetch-event-source/pull/8) are the minimal ones I had to do to get FetchEventSource working in a web worker context.
I've also added some unit tests to validate these changes.


With it one can use FetchEventSource in a WebWorker by settings these parameters : 
```js
fetchEventSource('https://myurl', {
    openWhenHidden: true,
    fetch: self.fetch,
    .....
```