### PR TITLE
Pr/add auto reconnect feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fetch-event-source",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A better API for making Event Source requests, with all the features of fetch()",
   "homepage": "https://github.com/Azure/fetch-event-source#readme",
   "repository": "github:Azure/fetch-event-source",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fetch-event-source",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "A better API for making Event Source requests, with all the features of fetch()",
   "homepage": "https://github.com/Azure/fetch-event-source#readme",
   "repository": "github:Azure/fetch-event-source",

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,2 @@
+export class FatalError extends Error {}
+export class RetryableError extends Error {}

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -100,6 +100,9 @@ export function fetchEventSource(input: RequestInfo, {
         const fetch = inputFetch ?? window.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
+            if (curRequestController) {
+                curRequestController.abort();
+            }
             curRequestController = new AbortController();
             try {
                 const response = await fetch(input, {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,4 +1,5 @@
 import { EventSourceMessage, getBytes, getLines, getMessages } from './parse';
+import {FatalError} from "./error";
 
 export const EventStreamContentType = 'text/event-stream';
 
@@ -167,6 +168,9 @@ export function fetchEventSource(input: RequestInfo, {
 function defaultOnOpen(response: Response) {
     const contentType = response.headers.get('content-type');
     if (!contentType?.startsWith(EventStreamContentType)) {
-        throw new Error(`Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`);
+        throw new FatalError(`Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`);
+    }
+    if (response.status == 204) {
+        throw new FatalError(`Received response code HTTP 204 (No Content)`)
     }
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -74,20 +74,20 @@ export function fetchEventSource(input: RequestInfo, {
         let curRequestController: AbortController;
         function onVisibilityChange() {
             curRequestController.abort(); // close existing request on every visibility change
-            if (!document.hidden) {
+            if (!self.document?.hidden) {
                 create(); // page is now visible again, recreate request.
             }
         }
 
-        if (!openWhenHidden) {
-            document.addEventListener('visibilitychange', onVisibilityChange);
+        if (self.document && !openWhenHidden) {
+            self.document?.addEventListener('visibilitychange', onVisibilityChange);
         }
 
         let retryInterval = DefaultRetryInterval;
         let retryTimer = 0;
         function dispose() {
-            document.removeEventListener('visibilitychange', onVisibilityChange);
-            window.clearTimeout(retryTimer);
+            self.document?.removeEventListener('visibilitychange', onVisibilityChange);
+            self.clearTimeout(retryTimer);
             curRequestController.abort();
         }
 
@@ -97,7 +97,7 @@ export function fetchEventSource(input: RequestInfo, {
             resolve(); // don't waste time constructing/logging errors
         });
 
-        const fetch = inputFetch ?? window.fetch;
+        const fetch = inputFetch ?? self.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
             if (curRequestController) {
@@ -134,8 +134,8 @@ export function fetchEventSource(input: RequestInfo, {
                     try {
                         // check if we need to retry:
                         const interval: any = onerror?.(err) ?? retryInterval;
-                        window.clearTimeout(retryTimer);
-                        retryTimer = window.setTimeout(create, interval);
+                        self.clearTimeout(retryTimer);
+                        retryTimer = self.setTimeout(create, interval);
                     } catch (innerErr) {
                         // we should not retry anymore:
                         dispose();

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -74,20 +74,20 @@ export function fetchEventSource(input: RequestInfo, {
         let curRequestController: AbortController;
         function onVisibilityChange() {
             curRequestController.abort(); // close existing request on every visibility change
-            if (!self.document?.hidden) {
+            if (!globalThis.document?.hidden) {
                 create(); // page is now visible again, recreate request.
             }
         }
 
-        if (self.document && !openWhenHidden) {
-            self.document?.addEventListener('visibilitychange', onVisibilityChange);
+        if (globalThis.document && !openWhenHidden) {
+            globalThis.document?.addEventListener('visibilitychange', onVisibilityChange);
         }
 
         let retryInterval = DefaultRetryInterval;
         let retryTimer = 0;
         function dispose() {
-            self.document?.removeEventListener('visibilitychange', onVisibilityChange);
-            self.clearTimeout(retryTimer);
+            globalThis.document?.removeEventListener('visibilitychange', onVisibilityChange);
+            globalThis.clearTimeout(retryTimer);
             curRequestController.abort();
         }
 
@@ -97,7 +97,7 @@ export function fetchEventSource(input: RequestInfo, {
             resolve(); // don't waste time constructing/logging errors
         });
 
-        const fetch = inputFetch ?? self.fetch;
+        const fetch = inputFetch ?? globalThis.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
             if (curRequestController) {
@@ -134,8 +134,8 @@ export function fetchEventSource(input: RequestInfo, {
                     try {
                         // check if we need to retry:
                         const interval: any = onerror?.(err) ?? retryInterval;
-                        self.clearTimeout(retryTimer);
-                        retryTimer = self.setTimeout(create, interval);
+                        globalThis.clearTimeout(retryTimer);
+                        retryTimer = globalThis.setTimeout(create, interval);
                     } catch (innerErr) {
                         // we should not retry anymore:
                         dispose();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { fetchEventSource, FetchEventSourceInit, EventStreamContentType } from './fetch';
 export { EventSourceMessage } from './parse';
+export { FatalError, RetryableError} from './error';


### PR DESCRIPTION
Add `autoReconnect` feature. If the connection is closed, fetchEventSource should automatically reconnect. Currently it does so only when an error is received. With this change, if new property `autoReconnect` is set to true, fetchEventSource will also try to reconnect when the connection is closed without an error.