### PR TITLE
Improved event stream checking example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class FatalError extends Error { }
 
 fetchEventSource('/api/sse', {
     async onopen(response) {
-        if (response.ok && response.headers.get('content-type') === EventStreamContentType) {
+        if (response.ok && response.headers.get('content-type').startsWith('text/event-stream')) {
             return; // everything's good
         } else if (response.status >= 400 && response.status < 500 && response.status !== 429) {
             // client-side errors are usually non-retriable:

--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ fetchEventSource('/api/sse', {
 
 You can add better error handling, for example:
 ```ts
+import { EventStreamContentType } from '@microsoft/fetch-event-source';
+
 class RetriableError extends Error { }
 class FatalError extends Error { }
 
 fetchEventSource('/api/sse', {
     async onopen(response) {
-        if (response.ok && response.headers.get('content-type').startsWith('text/event-stream')) {
+        if (response.ok && response.headers.get('content-type').startsWith(EventStreamContentType)) {
             return; // everything's good
         } else if (response.status >= 400 && response.status < 500 && response.status !== 429) {
             // client-side errors are usually non-retriable:


### PR DESCRIPTION
A tiny example update replacing equal condition for `EventStreamContentType` by checking with `startsWith` function.

```diff
- response.headers.get('content-type') === EventStreamContentType
+ response.headers.get('content-type').startsWith('text/event-stream')
```

covers cases when charset present: `Content-Type: text/event-stream; UTF-8`.

Added import of `EventStreamContentType` variable to take it more clear.