### PR TITLE
fix: create a new controller before dispose, cause loop request when …

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -100,7 +100,7 @@ export function fetchEventSource(input: RequestInfo, {
         const fetch = inputFetch ?? window.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
-            curRequestController = new AbortController();
+            curRequestController = curRequestController || new AbortController();
             try {
                 const response = await fetch(input, {
                     ...rest,


### PR DESCRIPTION
hi, this is my case.
 
sometimes, call create before dispose when caught exception, but curRequestController get a new AbortController, so it doesn't work.

```
async function create() {
  curRequestController = new AbortController();
  try {
    ....
   } catch (err) {
       retryTimer = window.setTimeout(create, interval);
       dispose();
  }
```

so , i fixed it by use origin curRequestController first:

```
curRequestController = curRequestController || new AbortController();
```