### PR TITLE
fix：empty line break is ignored during parsing

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -142,8 +142,8 @@ export function getMessages(
                     // if this message already has data, append the new value to the old.
                     // otherwise, just set to the new value:
                     message.data = message.data
-                        ? message.data + '\n' + value
-                        : value; // otherwise, 
+                        ? message.data + (value || '\n')
+                        : value || '\n'; // otherwise,
                     break;
                 case 'event':
                     message.event = value;


### PR DESCRIPTION
for message:  "id:111111\nevent:add\ndata:\ndata:more\n\n"

**before:**
parse result is:
```json
{
id: "11111",
event: "add",
data: "more"
}
```

**now:**
parse result is:
```json
{
id: "11111",
event: "add",
data: "\nmore"
}
```
