### PR TITLE
fix: Resolve race condition in AbortController handling during tab visibility changes

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -100,7 +100,8 @@ export function fetchEventSource(input: RequestInfo, {
         const fetch = inputFetch ?? window.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
-            curRequestController = new AbortController();
+            const currentController = new AbortController();
+            curRequestController = currentController;
             try {
                 const response = await fetch(input, {
                     ...rest,
@@ -126,7 +127,7 @@ export function fetchEventSource(input: RequestInfo, {
                 dispose();
                 resolve();
             } catch (err) {
-                if (!curRequestController.signal.aborted) {
+                if (!currentController.signal.aborted) {
                     // if we haven't aborted the request ourselves:
                     try {
                         // check if we need to retry:

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -100,6 +100,17 @@ export function fetchEventSource(input: RequestInfo, {
         const fetch = inputFetch ?? window.fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
+            // Store the AbortController instance in function scope to prevent race conditions
+            // This ensures that when error handling occurs, we check the abort status
+            // of the correct controller instance that was associated with this specific request,
+            // rather than potentially checking a new controller created by a subsequent request.
+            // 
+            // Race condition example:
+            // 1. Request A starts with Controller A
+            // 2. Tab becomes hidden -> Controller A is aborted
+            // 3. Tab becomes visible -> Request B starts with Controller B
+            // 4. Request A's error handler executes
+            // Without this fix, it would check Controller B's status instead of A's
             const currentController = new AbortController();
             curRequestController = currentController;
             try {


### PR DESCRIPTION
## Issue
close #95 
A race condition exists in the error handling of aborted requests when rapidly switching browser tabs. This causes unnecessary request retries and incorrect error handling behavior.

### Current Behavior
When switching browser tabs quickly:
1. Request A is initiated with AbortController instance A
2. Tab becomes hidden -> Controller A's abort() is called
3. Tab becomes visible -> Request B starts with Controller B
4. Request A's error handler executes but incorrectly checks Controller B's status
5. This leads to unnecessary retries of intentionally aborted requests

### Root Cause
The issue stems from using a shared global `curRequestController` variable across different async contexts. When error handling occurs asynchronously, it may check the abort status of a different controller instance than the one that initiated the request.

### Solution
Store the AbortController instance in the function scope to ensure each request's error handling uses its own controller:

```typescript
- curRequestController = new AbortController();
+ const currentController = new AbortController();
+ curRequestController = currentController;
  // Later in catch block:
- if (!curRequestController.signal.aborted)
+ if (!currentController.signal.aborted)
```

### Impact
- Eliminates unnecessary request retries
- Correctly handles tab visibility changes
- Improves error handling accuracy
- No breaking changes to public API

### Testing
Verified by:

- Rapidly switching browser tabs
- Confirming aborted requests don't trigger retries
- Ensuring normal retry behavior for actual errors remains unchanged