### PR TITLE
Checking signal abort status before doing anything else

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -64,6 +64,10 @@ export function fetchEventSource(input: RequestInfo, {
     fetch: inputFetch,
     ...rest
 }: FetchEventSourceInit) {
+    // Request leak if input signal aborted before the subscription even started.
+    if (inputSignal?.aborted) {
+        return;
+    }
     return new Promise<void>((resolve, reject) => {
         // make a copy of the input headers since we may modify it below:
         const headers = { ...inputHeaders };


### PR DESCRIPTION
Request can remain open if the input signal aborted status is not checked. The caller should check themselves, but just in case they forgot (I did), doing nothing is better than having orphaned connections.